### PR TITLE
Always assign city name; Remove region names or United States

### DIFF
--- a/app/src/main/java/com/paranoidandroid/journey/wizard/fragments/LegsFragment.java
+++ b/app/src/main/java/com/paranoidandroid/journey/wizard/fragments/LegsFragment.java
@@ -110,10 +110,7 @@ public class LegsFragment extends WizardFragment {
                     public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
                         input.setText("");
                         LegItem item = acAdapter.getItem(i);
-                        Destination destination = JourneyBuilder.findDestination(item.getPlacesId());
-                        String displayName = generateDisplayName(item.getDestination());
-                        destination.setDisplayName(displayName);
-                        destination.setGooglePlaceId(item.getPlacesId());
+                        Destination destination = JourneyBuilder.findDestination(item.getPlacesId(), item.getDestination());
                         Leg leg = new Leg();
                         leg.setDestination(destination);
                         adapter.add(leg);
@@ -122,17 +119,6 @@ public class LegsFragment extends WizardFragment {
             }
         });
 
-    }
-
-    private String generateDisplayName(String destination) {
-        String[] components = destination.split(",");
-        if (components.length == 2) {
-            return destination;
-        } else if (components[2].equals(" United States")) {
-            return components[0] + "," + components[1];
-        } else {
-            return components[0] + "," + components[components.length -1];
-        }
     }
 
     private void loadJourneyLegs(String journeyId) {

--- a/app/src/main/java/com/paranoidandroid/journey/wizard/fragments/LegsFragment.java
+++ b/app/src/main/java/com/paranoidandroid/journey/wizard/fragments/LegsFragment.java
@@ -111,7 +111,8 @@ public class LegsFragment extends WizardFragment {
                         input.setText("");
                         LegItem item = acAdapter.getItem(i);
                         Destination destination = JourneyBuilder.findDestination(item.getPlacesId());
-                        destination.setDisplayName(item.getDestination());
+                        String displayName = generateDisplayName(item.getDestination());
+                        destination.setDisplayName(displayName);
                         destination.setGooglePlaceId(item.getPlacesId());
                         Leg leg = new Leg();
                         leg.setDestination(destination);
@@ -121,6 +122,17 @@ public class LegsFragment extends WizardFragment {
             }
         });
 
+    }
+
+    private String generateDisplayName(String destination) {
+        String[] components = destination.split(",");
+        if (components.length == 2) {
+            return destination;
+        } else if (components[2].equals(" United States")) {
+            return components[0] + "," + components[1];
+        } else {
+            return components[0] + "," + components[components.length -1];
+        }
     }
 
     private void loadJourneyLegs(String journeyId) {

--- a/app/src/main/java/com/paranoidandroid/journey/wizard/utils/JourneyBuilder.java
+++ b/app/src/main/java/com/paranoidandroid/journey/wizard/utils/JourneyBuilder.java
@@ -85,6 +85,12 @@ public class JourneyBuilder {
                                 break;
                             }
                         }
+
+                        // use first part of display name if no city is present
+                        if (destination.getCityName() == null) {
+                            String[] components = destination.getDisplayName().replaceAll("\\s+","").split(",");
+                            destination.setCityName(components[0]);
+                        }
                     }
                     JSONObject location = result.getJSONObject("geometry").getJSONObject("location");
                     destination.setGeoPoint(location.getDouble("lat"), location.getDouble("lng"));

--- a/app/src/main/java/com/paranoidandroid/journey/wizard/utils/JourneyBuilder.java
+++ b/app/src/main/java/com/paranoidandroid/journey/wizard/utils/JourneyBuilder.java
@@ -62,9 +62,11 @@ public class JourneyBuilder {
         journey.setTripTags((List<String>) journeyParts.get(TAGS_KEY));
     }
 
-    public static Destination findDestination(String placeId) {
+    public static Destination findDestination(String placeId, String displayName) {
 
         final Destination destination = new Destination();
+        destination.setGooglePlaceId(placeId);
+        destination.setDisplayName(generateDisplayName(displayName));
 
         GooglePlaceSearchClient.getPlaceDetails(placeId, new JsonHttpResponseHandler(){
             @Override
@@ -107,6 +109,17 @@ public class JourneyBuilder {
         });
 
         return destination;
+    }
+    
+    private static String generateDisplayName(String destination) {
+        String[] components = destination.split(",");
+        if (components.length <= 2) {
+            return destination;
+        } else if (components[2].equals(" United States")) {
+            return components[0] + "," + components[1];
+        } else {
+            return components[0] + "," + components[components.length -1];
+        }
     }
 
 }

--- a/app/src/main/java/com/paranoidandroid/journey/wizard/utils/JourneyBuilder.java
+++ b/app/src/main/java/com/paranoidandroid/journey/wizard/utils/JourneyBuilder.java
@@ -88,12 +88,14 @@ public class JourneyBuilder {
                             }
                         }
 
-                        // use first part of display name if no city is present
-                        if (destination.getCityName() == null) {
-                            String[] components = destination.getDisplayName().replaceAll("\\s+","").split(",");
-                            destination.setCityName(components[0]);
-                        }
                     }
+
+                    // use first part of display name if no city is present
+                    if (destination.getCityName() == null) {
+                        String[] components = destination.getDisplayName().replaceAll("\\s+","").split(",");
+                        destination.setCityName(components[0]);
+                    }
+
                     JSONObject location = result.getJSONObject("geometry").getJSONObject("location");
                     destination.setGeoPoint(location.getDouble("lat"), location.getDouble("lng"));
 
@@ -110,7 +112,7 @@ public class JourneyBuilder {
 
         return destination;
     }
-    
+
     private static String generateDisplayName(String destination) {
         String[] components = destination.split(",");
         if (components.length <= 2) {


### PR DESCRIPTION
1) Always assign city

2) Remove "United States" from display name; [City, State] will be displayed

3) Remove regions from display name if not USA.