### PR TITLE
Fix sticky marker when zoomed in

### DIFF
--- a/app/src/main/java/com/paranoidandroid/journey/legplanner/fragments/MapViewFragment.java
+++ b/app/src/main/java/com/paranoidandroid/journey/legplanner/fragments/MapViewFragment.java
@@ -149,6 +149,8 @@ public class MapViewFragment extends Fragment implements
             markers.add(null);
         // Clear all the map
         mGoogleMap.clear();
+        // Nullify selected marker to release its reference
+        selectedMarker = null;
 
         builder = new LatLngBounds.Builder();
         LatLng prev = null; int index = 0;


### PR DESCRIPTION
There was an instance variable called `selectedMarker` of type `Marker`, which was apparently not garbage collected when the map was cleared. There was still a reference to this `Marker` so apparently the map would still show it.

Nullifying the `selectedMarker` fixes this issue.
